### PR TITLE
Added condition that makes OAuth authentication optional

### DIFF
--- a/backend/pzserver/settings.py
+++ b/backend/pzserver/settings.py
@@ -87,12 +87,12 @@ WSGI_APPLICATION = "pzserver.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": os.getenv("SQL_ENGINE", "django.db.backends.sqlite3"),
-        "NAME": os.getenv("SQL_DATABASE", os.path.join(BASE_DIR, "db.sqlite3")),
-        "USER": os.getenv("SQL_USER", "user"),
-        "PASSWORD": os.getenv("SQL_PASSWORD", "password"),
-        "HOST": os.getenv("SQL_HOST", "localhost"),
-        "PORT": os.getenv("SQL_PORT", "5432"),
+        "ENGINE": os.getenv("DB_ENGINE", "django.db.backends.sqlite3"),
+        "NAME": os.getenv("DB_DATABASE", os.path.join(BASE_DIR, "db.sqlite3")),
+        "USER": os.getenv("DB_USER", "user"),
+        "PASSWORD": os.getenv("DB_PASSWORD", "password"),
+        "HOST": os.getenv("DB_HOST", "localhost"),
+        "PORT": os.getenv("DB_PORT", "5432"),
     }
 }
 
@@ -137,10 +137,14 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # 'DJANGO_ALLOWED_HOSTS' should be a single string of hosts with a space
 # between each. For example: 'DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]'
-ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "*").split(" ")
+ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "localhost 127.0.0.1 [::1]").split(
+    " "
+)
 
 # https://docs.djangoproject.com/en/4.0/releases/4.0/#csrf-trusted-origins-changes
-CSRF_TRUSTED_ORIGINS = os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "*").split(" ")
+CSRF_TRUSTED_ORIGINS = os.getenv(
+    "DJANGO_CSRF_TRUSTED_ORIGINS", "http://localhost http://127.0.0.1"
+).split(" ")
 
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
@@ -175,11 +179,12 @@ AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.ModelBackend",
 )
 
-SOCIAL_AUTH_GITHUB_ORG_KEY = os.getenv("GITHUB_CLIENT_ID", None)
-SOCIAL_AUTH_GITHUB_ORG_SECRET = os.getenv("GITHUB_CLIENT_SECRET", None)
-SOCIAL_AUTH_GITHUB_ORG_NAME = os.getenv("GITHUB_ORG_NAME", "linea-it")
-SOCIAL_AUTH_GITHUB_ORG_SCOPE = ["user:email", "read:org"]
-SOCIAL_AUTH_JSONFIELD_ENABLED = True
+if os.getenv("GITHUB_CLIENT_ID", None) is not None:
+    SOCIAL_AUTH_GITHUB_ORG_KEY = os.getenv("GITHUB_CLIENT_ID")
+    SOCIAL_AUTH_GITHUB_ORG_SECRET = os.getenv("GITHUB_CLIENT_SECRET")
+    SOCIAL_AUTH_GITHUB_ORG_NAME = os.getenv("GITHUB_ORG_NAME", "linea-it")
+    SOCIAL_AUTH_GITHUB_ORG_SCOPE = ["user:email", "read:org"]
+    SOCIAL_AUTH_JSONFIELD_ENABLED = True
 
 LOGIN_REDIRECT_URL = "/api/"
 ACTIVATE_JWT = True

--- a/env_template
+++ b/env_template
@@ -17,11 +17,13 @@ DB_DATABASE=pzdev
 DB_HOST=database
 DB_PORT=5432
 
-# Github OAuth
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
-GITHUB_ORG_NAME=linea-it
-
 # CORS
-DJANGO_ALLOWED_HOSTS=
-DJANGO_CSRF_TRUSTED_ORIGINS=
+DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
+DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost http://127.0.0.1
+
+# Github OAuth
+# To enable Github OAuth authentication, 
+# uncomment and fill in the following variables.
+#GITHUB_CLIENT_ID=
+#GITHUB_CLIENT_SECRET=
+#GITHUB_ORG_NAME=linea-it


### PR DESCRIPTION
Adicionei uma condição no settings.py para só habilitar o github oauth caso a variavel SOCIAL_AUTH_GITHUB_ORG_KEY tenha valor. 
Deixei no env_template a variavel comentada por default. isso é para facilicar o ambiente do desenvolvedor que não precisar ter o OAuth configurado e também o ambiente de testes automatizados. 

**Importante** Alterei as variaveis de config do banco, substitui SQL_ por DB_ só para ficar igual aos outros apps. 