### PR TITLE
Added filter by user in product endpoint

### DIFF
--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django import forms
 from core.models import (
     ProductType,
     Product,
@@ -25,6 +26,14 @@ class ReleaseAdmin(admin.ModelAdmin):
     search_fields = ("name", "display_name")
 
 
+class ProductAdminForm(forms.ModelForm):
+    class Meta:
+        model = Product
+        exclude = ["path"]
+        # widgets = {"path": forms.RadioSelect}
+        # fields = "__all__"  # required for Django 3.x
+
+
 @admin.register(Product)
 class ProductAdmin(admin.ModelAdmin):
     list_display = (
@@ -42,6 +51,12 @@ class ProductAdmin(admin.ModelAdmin):
     )
 
     search_fields = ("name", "display_name")
+
+    form = ProductAdminForm
+
+    # This will help you to disbale add functionality
+    def has_add_permission(self, request):
+        return False
 
 
 @admin.register(ProductContent)

--- a/backend/core/models/product.py
+++ b/backend/core/models/product.py
@@ -47,7 +47,9 @@ class Product(models.Model):
         default=ProductStatus.REGISTERING,
         choices=ProductStatus.choices,
     )
-    path = models.FilePathField(verbose_name="Path", null=True, blank=True, default=None)
+    path = models.FilePathField(
+        verbose_name="Path", null=True, blank=True, default=None
+    )
 
     def __str__(self):
         return f"{self.display_name}"

--- a/backend/core/serializers/__init__.py
+++ b/backend/core/serializers/__init__.py
@@ -3,3 +3,4 @@ from core.serializers.product_type import ProductTypeSerializer
 from core.serializers.product import ProductSerializer
 from core.serializers.product_content import ProductContentSerializer
 from core.serializers.product_file import ProductFileSerializer
+from core.serializers.user import UserSerializer

--- a/backend/core/serializers/release.py
+++ b/backend/core/serializers/release.py
@@ -1,7 +1,5 @@
 from rest_framework import serializers
 from core.models import Release
-
-
 class ReleaseSerializer(serializers.ModelSerializer):
     class Meta:
         model = Release

--- a/backend/core/serializers/user.py
+++ b/backend/core/serializers/user.py
@@ -1,0 +1,28 @@
+from rest_framework import serializers
+from django.contrib.auth.models import User
+
+
+class UserSerializer(serializers.ModelSerializer):
+    display_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ("username", "first_name", "last_name", "display_name")
+        # exclude = [
+        #     "id",
+        #     "password",
+        #     "last_login",
+        #     "is_superuser",
+        #     "email",
+        #     "is_staff",
+        #     "is_active",
+        #     "date_joined",
+        #     "groups",
+        #     "user_permissions",
+        # ]
+
+    def get_display_name(self, obj):
+        try:
+            return obj.profile.display_name
+        except:
+            return None

--- a/backend/core/views/__init__.py
+++ b/backend/core/views/__init__.py
@@ -7,3 +7,4 @@ from core.views.user import LoggedUserView
 from core.views.user import GetToken
 from core.views.user import CsrfToOauth
 from core.views.user import Logout
+from core.views.user import UserViewSet

--- a/backend/core/views/user.py
+++ b/backend/core/views/user.py
@@ -14,6 +14,9 @@ from rest_framework.views import APIView
 from django.contrib.auth import logout
 import requests
 import logging
+from rest_framework import viewsets
+from django.contrib.auth.models import User
+from core.serializers.user import UserSerializer
 
 
 class LoggedUserView(APIView):
@@ -150,3 +153,8 @@ class CsrfToOauth(APIView):
             secure=settings.SESSION_COOKIE_SECURE or None,
         )
         return response
+
+
+class UserViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer

--- a/backend/pzserver/urls.py
+++ b/backend/pzserver/urls.py
@@ -28,6 +28,7 @@ from core.views import (
     GetToken,
     Logout,
     CsrfToOauth,
+    UserViewSet,
 )
 from drf_spectacular.views import (
     SpectacularAPIView,
@@ -37,6 +38,7 @@ from drf_spectacular.views import (
 
 route = routers.DefaultRouter()
 
+route.register(r"users", UserViewSet, basename="users")
 route.register(r"releases", ReleaseViewSet, basename="Releases")
 route.register(r"product-files", ProductFileViewSet, basename="ProductFiles")
 route.register(r"product-contents", ProductContentViewSet, basename="ProductContents")


### PR DESCRIPTION
- Adicionado endpoint que retorna os usernames
- Adicionado filtro por username, first_name, last_name no endpoint de produtos. 
- Adicionado username, first_name, last_name na search de produtos. 

Exemplos:

Endpoint Users: 
http://localhost/api/users/

Filtro por usuario na lista de produtos. 
A busca considera o valor passado no parametro uploaded_by como uma query like case insensitive.  
algo como username ilike  %param% OR first_name ilike %param% OR last_name ilike %param%
Exemplos: 
Considerando nome de usuário gverde:
http://localhost/api/products/?uploaded_by=gverde
http://localhost/api/products/?uploaded_by=g
http://localhost/api/products/?uploaded_by=erde

Procurar produtos de um usuario usando Search (Interface ou API)
http://localhost/api/products/?search=gverde
Neste caso o Search considera os campos         "product__display_name",  "user__username", "user__first_name", "user__last_name",

Acredito que esse conjunto de mudanças cubra todos os casos de uso relacionado a encontrar um produto pelo usuário que fez o upload.

