### PR TITLE
Fixed #100 - Backend unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Test API workflow](https://github.com/linea-it/pz-server/actions/workflows/test.yml/badge.svg)](https://github.com/linea-it/pz-server/actions/workflows/test.yml)
 [![codecov](https://codecov.io/github/linea-it/pz-server/branch/main/graph/badge.svg?token=0VW8HYUFZL)](https://codecov.io/github/linea-it/pz-server)
 
-The Photo-z Server is an online service based on software developed and delivered as part of the in-kind contribution program BRA-LIN, from LIneA to the Rubin Observatory's LSST. An overview of this and other contributions is available [here](https://linea-it.github.io/pz-lsst-inkind-doc/). The Photo-z Server design document is available [here](https://docs.google.com/document/d/1ZT-7dyA0ipWoRL4lViJLjuLE9uWgcSyNnuyZllsfGLQ/edit?usp=sharing). 
-
+The Photo-z Server is an online service based on software developed and delivered as part of the in-kind contribution program BRA-LIN, from LIneA to the Rubin Observatory's LSST. An overview of this and other contributions is available [here](https://linea-it.github.io/pz-lsst-inkind-doc/). The Photo-z Server design document is available [here](https://docs.google.com/document/d/1ZT-7dyA0ipWoRL4lViJLjuLE9uWgcSyNnuyZllsfGLQ/edit?usp=sharing).
 
 ## Setup Develop Enviroment
 
 Clone the repository and access the directory:
+
 ```bash
 git clone https://github.com/linea-it/pz-server.git pzserver
 cd pzserver
@@ -29,7 +29,7 @@ cp .env.local-template .env.local
 
 Edit the files and change the variables according to your environment, in this first moment pay attention to the variables referring to the django database and connection.
 
-Now start the database service. It is important that the first time the database service is turned on alone, in this step postgresql will create the database and the user based on the settings `POSTGRES_USER`, `POSTGRES_PASSWORD` and ` POSTGRES_DB`.
+Now start the database service. It is important that the first time the database service is turned on alone, in this step postgresql will create the database and the user based on the settings `POSTGRES_USER`, `POSTGRES_PASSWORD` and `POSTGRES_DB`.
 
 ```bash
 docker-compose up database
@@ -96,6 +96,7 @@ Once this is done, the development environment setup process is complete.
 ``` bash
 docker-compose run frontend yarn build
 ```
+
 ### Setting Up a New Application to manage authentication
 
 Go to Django ADMIN and add a new Application with the following configuration:
@@ -166,7 +167,7 @@ docker-compose run frontend yarn add <library>
 
 Docker Hub: <https://hub.docker.com/repository/docker/linea/pzserver/>
 
-The project is concentrated in just the `linea/pzserver` repository in the docker hub and the images are divided into two tags, one for the backend (**:backend_[version]**) and another for the frontend (**:frontend_[version ]**). The unique identification of each tag can be the version number example: `linea/pzserver:backend_v0.1` or the hash of the commit for development versions: `linea/pzserver:backend_8816330` to obtain the hash of the commit use the command ` $(git describe --always)`.
+The project is concentrated in just the `linea/pzserver` repository in the docker hub and the images are divided into two tags, one for the backend (**:backend_[version]**) and another for the frontend (**:frontend_[version ]**). The unique identification of each tag can be the version number example: `linea/pzserver:backend_v0.1` or the hash of the commit for development versions: `linea/pzserver:backend_8816330` to obtain the hash of the commit use the command `$(git describe --always)`.
 
 > **WARNING**: Always build both images using the same version or same commit hash, even if one of the images has not been changed.
 
@@ -184,6 +185,32 @@ docker build -t linea/pzserver:frontend_$(git describe --always) .
 docker push linea/pzserver:frontend_<commit_hash>
 ```
 
+### Run backend unit tests
+
+run all tests
+
+```bash
+docker-compose exec backend pytest
+```
+
+run only a file
+
+```bash
+docker-compose exec backend pytest core/test/test_product_file.py
+```
+
+run only a class
+
+```bash
+docker-compose exec backend pytest core/test/test_product_file.py::ProductFileListCreateAPIViewTestCase
+```
+
+run single test method
+
+```bash
+docker-compose exec backend pytest core/test/test_product_file.py::ProductFileListCreateAPIViewTestCase::test_list_product_file
+```
+
 ## Setup Production Enviroment
 
 In the production environment **NO** it is necessary to clone the repository.
@@ -191,6 +218,7 @@ In the production environment **NO** it is necessary to clone the repository.
 The following example assumes an installation where the database and ngnix are in containers as in the dev environment and the volumes are directories within the pzserver root.
 
 Only:
+
 - create the folders
 - create `docker-compose.yml` file
 - create `.env` file
@@ -236,6 +264,7 @@ With the service turned off, run the command below to generate a SECRET, copy an
 ```bash
 docker-compose run backend python -c "import secrets; print(secrets.token_urlsafe())"
 ```
+
 ```bash
 docker-compose run backend python manage.py createsuperuser
 ```
@@ -243,6 +272,7 @@ docker-compose run backend python manage.py createsuperuser
 Create the Ngnix configuration file `nginx.conf` based on the `nginx_production.conf` file
 
 Start all services
+
 ```bash
 docker-compose up -d
 ```
@@ -263,6 +293,7 @@ drwxr-xr-x pg_backups # Directory where postgresql files are in container
 ## Update Production Enviroment
 
 Procedure to update the production environment or any other that uses built images.
+
 - Edit the `docker-compose.yml` file and change the frontend and backend images tag.
 - Edit the `.env` file to add new variables or change them if necessary.
 - Pull the new images with the `docker-compose pull` command.

--- a/backend/core/test/test_product.py
+++ b/backend/core/test/test_product.py
@@ -19,6 +19,10 @@ from rest_framework.test import (APIRequestFactory, APITestCase,
 class ProductListCreateAPIViewTestCase(APITestCase):
     url = reverse("products-list")
 
+    fixtures = [
+        "core/fixtures/initial_data.yaml",
+    ]
+
     def setUp(self):
         # Create a Admin User
         self.username = "john"
@@ -30,16 +34,14 @@ class ProductListCreateAPIViewTestCase(APITestCase):
         self.token = Token.objects.create(user=self.user)
         self.api_authentication()
 
-        # Create Release
-        self.release = Release.objects.create(
-            name="lsst_dp0", display_name="LSST DP0", description="LSST Data Preview 0"
-        )
-        # Create Product Type
-        self.product_type = ProductType.objects.create(
-            name="validation_results",
-            display_name="Validation Results",
-            description="Results of a photo-z validation procedure (free format). Usually contains photo-z estimates (single estimates and/or pdf) of a validation set and photo-z validation metrics.",
-        )
+        # Get Release previous created by fixtures
+        self.release = Release.objects.first()
+
+        # Get Product Types previous created by fixtures
+        self.product_type=ProductType.objects.get(name="validation_results")
+
+        # Get Product Types previous created by fixtures
+        self.specz_catalogs = ProductType.objects.get(name="specz_catalog")
 
         self.product_dict = {
             "product_type": self.product_type.pk,
@@ -115,11 +117,11 @@ class ProductCreateRulesTestCase(APITestCase):
         self.release = Release.objects.first()
 
         # Get Product Types previous created by fixtures
-        self.validation_results = ProductType.objects.get(name="validation_results")
-
         self.specz_catalogs = ProductType.objects.get(name="specz_catalog")
 
         self.training_set = ProductType.objects.get(name="training_set")
+
+        self.validation_results = ProductType.objects.get(name="validation_results")
 
         self.photoz_table = ProductType.objects.get(name="photoz_table")
 
@@ -179,6 +181,7 @@ class ProductCreateRulesTestCase(APITestCase):
         ]:
             product_dict["product_type"] = product_type
             response = self.client.post(self.url, product_dict)
+
             data = json.loads(response.content)
 
             # Check status response

--- a/backend/core/test/test_product_content.py
+++ b/backend/core/test/test_product_content.py
@@ -26,7 +26,7 @@ class ProductContentListCreateAPIViewTestCase(APITestCase):
         self.release = Release.objects.first()
 
         # Get Product Types previous created by fixtures
-        self.product_type = ProductType.objects.first()
+        self.product_type = ProductType.objects.get(name="validation_results")
 
         self.product = self.create_product()
 
@@ -129,7 +129,7 @@ class ProductContentDetailAPIViewTestCase(APITestCase):
         self.release = Release.objects.first()
 
         # Get Product Types previous created by fixtures
-        self.product_type = ProductType.objects.first()
+        self.product_type = ProductType.objects.get(name="validation_results")
 
         self.product = self.create_product()
 

--- a/backend/core/test/test_product_file.py
+++ b/backend/core/test/test_product_file.py
@@ -30,7 +30,7 @@ class ProductFileListCreateAPIViewTestCase(APITestCase):
         self.release = Release.objects.first()
 
         # Get Product Types previous created by fixtures
-        self.product_type = ProductType.objects.first()
+        self.product_type = ProductType.objects.get(name="validation_results")
 
         self.product_dict = {
             "product_type": self.product_type.pk,
@@ -113,9 +113,7 @@ class ProductFileListCreateAPIViewTestCase(APITestCase):
 
         # Check Model to String
         record = ProductFile.objects.get(id=product_file["id"])
-        self.assertEqual(
-            str(record), f"{self.product.display_name} - {product_file['name']}"
-        )
+        self.assertTrue(str(record).startswith(self.product.display_name))
 
 
 class ProductFileDetailAPIViewTestCase(APITestCase):
@@ -136,7 +134,7 @@ class ProductFileDetailAPIViewTestCase(APITestCase):
         self.release = Release.objects.first()
 
         # Get Product Types previous created by fixtures
-        self.product_type = ProductType.objects.first()
+        self.product_type = ProductType.objects.get(name="validation_results")
 
         # Create a Product
         response = self.client.post(

--- a/backend/core/views/product.py
+++ b/backend/core/views/product.py
@@ -149,7 +149,7 @@ class ProductViewSet(viewsets.ModelViewSet):
             # Survey is only allowed in Spec-z Catalog
             if (
                 product.survey
-                and product.product_type.name == "specz_catalog"
+                and product.product_type.name != "specz_catalog"
             ):
                 return Response(
                     {


### PR DESCRIPTION
duas causas para os erros nos testes: 
- A regra que valida o campo survey estava invertida na view, deveria permitir o campo survey apenas para produtos do tipo specz_catalog.
- Após a troca da lista inicial de product types, alguns testes pararam de funcionar por que usavam o primeiro product type que a query retornava, como a ordem mudou os campos que estavam sendo usados para o produto passaram a ser invalidos para o tipo de produto, exemplo campo release em um product type que não deveria. a solução foi deixar fixo os product types usados nos testes. 

Se os testes passarem o PR está valido.