### PR TITLE
Suport plain text catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ run all tests
 docker-compose exec backend pytest
 ```
 
+run all tests with coverage, Check local coverage in localhost/coverage
+
+```bash
+docker-compose exec backend pytest --cov=./ --cov-report=html
+```
+
 run only a file
 
 ```bash

--- a/backend/core/product_handle.py
+++ b/backend/core/product_handle.py
@@ -3,6 +3,7 @@ import csv
 from pathlib import Path
 from typing import List
 
+import numpy as np
 import pandas as pd
 import tables_io
 from core._typing import Column, PathLike
@@ -28,12 +29,10 @@ class ProductHandle:
 
 
 class FileHandle(object):
-
     handle = None
     extension = None
 
     def __init__(self, filepath: PathLike):
-
         fp = Path(filepath)
 
         # Identificar o formato do arquivo
@@ -49,8 +48,10 @@ class FileHandle(object):
                 self.handle = CompressedHandle(fp)
             # TODO: .zip, .tar, .tar.gz
             case _:
-                message = f"The {self.extension} extension has not yet been implemented"
-                raise NotImplementedError(message)
+                # Try TxtHandle
+                self.handle = TxtHandle(fp)
+                # message = f"The {self.extension} extension has not yet been implemented"
+                # raise NotImplementedError(message)
 
     def to_df(self, **kwargs):
         return self.handle.to_df(**kwargs)
@@ -68,14 +69,12 @@ class BaseHandle(object):
 
 
 class CsvHandle(BaseHandle):
-
     delimiter = str
     has_hd = bool  # True se o arquivo CSV possuir Headers na primeira linha.
     # Lista com nome das colunas que podem ser str ou int.
     column_names = [Column]
 
     def __init__(self, filepath: PathLike):
-
         super().__init__(filepath)
 
         self.delimiter = self.get_delimiter()
@@ -83,7 +82,6 @@ class CsvHandle(BaseHandle):
         self.column_names = self.get_column_names()
 
     def to_df(self, **kwargs) -> pd.DataFrame:
-
         # Check for header parameter
         if "header" in kwargs:
             raise Exception(
@@ -127,10 +125,8 @@ class CsvHandle(BaseHandle):
         # Method: open csv twice considering with header and without header,
         # if the data types are the same in both times it probably doesn't have header.
         # https://stackoverflow.com/questions/53100598/can-pandas-auto-recognize-if-header-is-present/53101192#53101192
-        df = pd.read_csv(self.filepath, header=None,
-                         delimiter=self.delimiter, nrows=20)
-        df_header = pd.read_csv(
-            self.filepath, delimiter=self.delimiter, nrows=20)
+        df = pd.read_csv(self.filepath, header=None, delimiter=self.delimiter, nrows=20)
+        df_header = pd.read_csv(self.filepath, delimiter=self.delimiter, nrows=20)
         if tuple(df.dtypes) != tuple(df_header.dtypes):
             temp.append(True)
         else:
@@ -145,9 +141,7 @@ class CsvHandle(BaseHandle):
         return all(temp)
 
     def get_column_names(self) -> List[Column]:
-
-        df = pd.read_csv(self.filepath, header=None,
-                         delimiter=self.delimiter, nrows=5)
+        df = pd.read_csv(self.filepath, header=None, delimiter=self.delimiter, nrows=5)
 
         if self.has_hd:
             df = df[1:].reset_index(drop=True).rename(columns=df.iloc[0])
@@ -174,7 +168,6 @@ class CsvHandle(BaseHandle):
 
 class TableIOHandle(BaseHandle):
     def __init__(self, filepath: PathLike):
-
         super().__init__(filepath)
 
     def to_df(self, **kwargs) -> pd.DataFrame:
@@ -191,10 +184,101 @@ class TableIOHandle(BaseHandle):
 
 class CompressedHandle(BaseHandle):
     def __init__(self, filepath: PathLike):
-
         super().__init__(filepath)
 
     def to_df(self, **kwargs) -> pd.DataFrame:
         raise NotTableError(
             "It is not possible to return a dataframe from this file type."
+        )
+
+
+class TxtHandle(BaseHandle):
+    delimiter = str
+    has_hd = bool
+    skiprows = int
+    # Lista com nome das colunas que podem ser str ou int.
+    column_names = [Column]
+
+    def __init__(self, filepath: PathLike):
+        super().__init__(filepath)
+
+        self.delimiter = self.get_delimiter()
+        # Heder False para todos os arquivos de formato não especificado.
+        self.has_hd = False
+
+        self.skiprows = self.count_skiprows()
+
+        self.column_names = self.get_column_names()
+
+    def to_df(self, **kwargs) -> pd.DataFrame:
+        # Try read table using numpy
+        # Ignore all lines start with #
+        # ignores all initial lines that after the split have only string.
+        # Acept space as delimiter.
+        # Does not accept string values.
+        df = pd.DataFrame(self.numpy_loadtxt())
+        # Rename columns in dataframe
+        df = df.set_axis(self.column_names, axis=1, inplace=False)
+
+        return df
+
+    def numpy_loadtxt(self, max_rows=None) -> np.ndarray:
+        try:
+            return np.loadtxt(self.filepath, skiprows=self.skiprows, max_rows=max_rows)
+        except ValueError as e:
+            msg = f"Invalid format. {str(e)}. For {self.filepath.suffix} files, all values must be numeric. Lines starting with # will be ignored."
+            raise ValueError(msg)
+
+    def get_column_names(self) -> List[Column]:
+        # Cria nomes para as colunas de forma sequencial [0...len(headers)]
+        # o Resultado é uma lista de str: ['0', ...,'10',...]
+        df = pd.DataFrame(self.numpy_loadtxt(max_rows=2))
+        columns = [str(i) for i in [*range(0, len(df.iloc[0]))]]
+
+        # Tenta ler o nome das colunas apenas para arquivos onde a primeira linha é toda de string.
+        if self.skiprows == 1:
+            with open(self.filepath, "r") as fp:
+                line = fp.readline().replace("\n", "")
+                if line.startswith("#"):
+                    line = line.strip("#").strip()
+
+                columns = [str(i).strip() for i in line.split()]
+
+        return columns
+
+    def get_delimiter(self):
+        """Get delimiter from file
+
+        Returns:
+            str: delimiter
+        """
+        with open(self.filepath, "r") as csvfile:
+            dt = csvfile.readline().replace("\n", "")
+            delimiter = csv.Sniffer().sniff(dt).delimiter
+
+        return delimiter
+
+    def count_skiprows(
+        self,
+    ):
+        count = 0
+        with open(self.filepath, "r") as f:
+            for line in f:
+                if line.startswith("#"):
+                    count += 1
+                elif self.valid_list(line):
+                    count += 1
+                else:
+                    return count
+
+    def isfloatstr(self, x):
+        try:
+            float(x)
+            return True
+        except ValueError:
+            return False
+
+    def valid_list(self, line):
+        return all(
+            (isinstance(el, str) and not self.isfloatstr(el)) for el in line.split()
         )

--- a/backend/core/test/test_product_handle.py
+++ b/backend/core/test/test_product_handle.py
@@ -82,18 +82,19 @@ class TestProductHandleClass(APITestCase):
                 "delimiter": " ",
                 "commented_lines": 5,
             },
+            {
+                "extension": "txt",
+                "header": False,
+                "compression": None,
+                "delimiter": " ",
+                "str_value": True,
+            },
         ]
 
     def test_df_from_file(self):
         for tcase in self.tcases:
             # Cria o arquivo de teste
-            sample_file = sample_product_file(
-                extension=tcase["extension"],
-                header=tcase["header"],
-                compression=tcase["compression"],
-                delimiter=tcase.get("delimiter", None),
-                commented_lines=tcase.get("commented_lines", 0),
-            )
+            sample_file = sample_product_file(**tcase)
 
             if tcase["compression"] != None:
                 with pytest.raises(NotTableError):
@@ -145,14 +146,14 @@ class TestProductHandleClass(APITestCase):
         with pytest.raises(NotImplementedError):
             BaseHandle(sample_file).to_df()
 
-    def test_txt_handle_value_error_exception(self):
-        sample_file = sample_product_file(
-            extension="txt",
-            header=True,
-            compression=None,
-            delimiter=" ",
-            commented_lines=0,
-            value_error=True,
-        )
-        with pytest.raises(ValueError):
-            ProductHandle().df_from_file(sample_file)
+    # def test_txt_handle_str_value_exception(self):
+    #     sample_file = sample_product_file(
+    #         extension="txt",
+    #         header=True,
+    #         compression=None,
+    #         delimiter=" ",
+    #         commented_lines=0,
+    #         str_value=True,
+    #     )
+    #     with pytest.raises(ValueError):
+    #         ProductHandle().df_from_file(sample_file)

--- a/backend/core/test/test_product_handle.py
+++ b/backend/core/test/test_product_handle.py
@@ -9,7 +9,6 @@ from rest_framework.test import APIRequestFactory, APITestCase
 
 class TestProductHandleClass(APITestCase):
     def setUp(self):
-
         self.countRows = 9
         self.columns = [
             "coadd_objects_id",
@@ -45,16 +44,55 @@ class TestProductHandleClass(APITestCase):
             {"extension": "pq", "header": True, "compression": None},
             {"extension": "pq", "header": True, "compression": "tar"},
             {"extension": "pq", "header": True, "compression": "gz"},
+            {
+                "extension": "txt",
+                "header": False,
+                "compression": None,
+                "delimiter": " ",
+            },
+            {
+                "extension": "txt",
+                "header": False,
+                "compression": None,
+                "delimiter": "  ",
+            },
+            {
+                "extension": "txt",
+                "header": False,
+                "compression": None,
+                "delimiter": ";",
+            },
+            {
+                "extension": "txt",
+                "header": True,
+                "compression": None,
+                "delimiter": " ",
+            },
+            {
+                "extension": "txt",
+                "header": True,
+                "compression": None,
+                "delimiter": " ",
+                "commented_lines": 1,
+            },
+            {
+                "extension": "txt",
+                "header": False,
+                "compression": None,
+                "delimiter": " ",
+                "commented_lines": 5,
+            },
         ]
 
     def test_df_from_file(self):
-
         for tcase in self.tcases:
             # Cria o arquivo de teste
             sample_file = sample_product_file(
                 extension=tcase["extension"],
                 header=tcase["header"],
                 compression=tcase["compression"],
+                delimiter=tcase.get("delimiter", None),
+                commented_lines=tcase.get("commented_lines", 0),
             )
 
             if tcase["compression"] != None:
@@ -88,15 +126,15 @@ class TestProductHandleClass(APITestCase):
         with pytest.raises(Exception):
             CsvHandle(sample_file).to_df(delimiter=",")
 
-    def test_extension_not_implemented_exception(self):
-        sample_file = sample_product_file(
-            extension="csv",
-            header=True,
-            compression=None,
-        )
-        sample_file.rename("/tmp/sample_file.dat")
-        with pytest.raises(NotImplementedError):
-            ProductHandle().df_from_file("/tmp/sample_file.dat")
+    # def test_extension_not_implemented_exception(self):
+    #     sample_file = sample_product_file(
+    #         extension="csv",
+    #         header=True,
+    #         compression=None,
+    #     )
+    #     sample_file.rename("/tmp/sample_file.dat")
+    #     with pytest.raises(NotImplementedError):
+    #         ProductHandle().df_from_file("/tmp/sample_file.dat")
 
     def test_base_handle_to_df_exception(self):
         sample_file = sample_product_file(
@@ -106,3 +144,15 @@ class TestProductHandleClass(APITestCase):
         )
         with pytest.raises(NotImplementedError):
             BaseHandle(sample_file).to_df()
+
+    def test_txt_handle_value_error_exception(self):
+        sample_file = sample_product_file(
+            extension="txt",
+            header=True,
+            compression=None,
+            delimiter=" ",
+            commented_lines=0,
+            value_error=True,
+        )
+        with pytest.raises(ValueError):
+            ProductHandle().df_from_file(sample_file)

--- a/backend/core/test/util.py
+++ b/backend/core/test/util.py
@@ -15,7 +15,7 @@ def sample_product_file(
     delimiter=";",
     comment="#",
     commented_lines=0,
-    value_error=False,
+    str_value=False,
 ):
     data = [
         {
@@ -92,7 +92,7 @@ def sample_product_file(
         },
     ]
 
-    if value_error:
+    if str_value:
         # Troca um dos valores do primeiro registro por uma string.
         data[0]["extendedness"] = "string_value"
 

--- a/nginx_development.conf
+++ b/nginx_development.conf
@@ -73,7 +73,7 @@ server {
       autoindex off;
     }
 
-    location /coverage/ {
+    location /coverage {
       alias /var/www/coverage/;
       try_files $uri $uri/ /index.html;
       autoindex off;


### PR DESCRIPTION
The reading of catalogs with undefined extension and format was implemented. instead of returning an exception the catalog will be read using numpy loadtxt. #92

Added TxtHandle class in product_handle. 
- Try read table using numpy.loadtxt
- Ignore all lines start with #
- ignores all initial lines that after the split have only string.
- Acept space as delimiter.
- Does not accept string values.
- If it is identified that it has only one header line, it tries to generate the columns from it. if there are multiple lines in the header, they will all be ignored and the columns will have a sequential name.